### PR TITLE
Set maximum number of data values in one import

### DIFF
--- a/src/components/import/ImportPage.js
+++ b/src/components/import/ImportPage.js
@@ -22,8 +22,6 @@ const Page = () => {
   const daysCount = getNumberOfDaysFromPeriod(period);
   const valueCount = orgUnitCount * daysCount;
 
-  console.log("valueCount", valueCount);
-
   const isValidOrgUnits =
     orgUnits?.parent &&
     orgUnits?.level &&

--- a/src/components/import/ImportPage.js
+++ b/src/components/import/ImportPage.js
@@ -6,8 +6,11 @@ import Period from "./Period";
 import OrgUnits from "./OrgUnits";
 import DataElement from "./DataElement";
 import ExtractData from "./ExtractData";
-import { defaultPeriod } from "../../utils/time";
+import useOrgUnitCount from "../../hooks/useOrgUnitCount";
+import { defaultPeriod, getNumberOfDaysFromPeriod } from "../../utils/time";
 import styles from "./styles/ImportPage.module.css";
+
+const maxValues = 50000;
 
 const Page = () => {
   const [dataset, setDataset] = useState();
@@ -15,6 +18,11 @@ const Page = () => {
   const [orgUnits, setOrgUnits] = useState();
   const [dataElement, setDataElement] = useState();
   const [startExtract, setStartExtract] = useState(false);
+  const orgUnitCount = useOrgUnitCount(orgUnits?.parent?.id, orgUnits?.level);
+  const daysCount = getNumberOfDaysFromPeriod(period);
+  const valueCount = orgUnitCount * daysCount;
+
+  console.log("valueCount", valueCount);
 
   const isValidOrgUnits =
     orgUnits?.parent &&
@@ -27,7 +35,8 @@ const Page = () => {
     period.endDate &&
     new Date(period.startDate) <= new Date(period.endDate) &&
     isValidOrgUnits &&
-    dataElement
+    dataElement &&
+    valueCount <= maxValues
   );
 
   useEffect(() => {
@@ -49,6 +58,19 @@ const Page = () => {
             />
             <Period period={period} onChange={setPeriod} />
             <OrgUnits selected={orgUnits} onChange={setOrgUnits} />
+            {valueCount > maxValues && (
+              <div className={styles.warning}>
+                {i18n.t(
+                  "You can maximum import {{maxValues}} values in a single import, but you are trying to import {{valueCount}} values for {{orgUnitCount}} organisation units over {{daysCount}} days. Please select a smaller period or fewer organisation units. You can always import more data later.",
+                  {
+                    maxValues,
+                    valueCount,
+                    orgUnitCount,
+                    daysCount,
+                  }
+                )}
+              </div>
+            )}
             <DataElement
               selected={dataElement}
               dataset={dataset}

--- a/src/components/import/ImportPage.js
+++ b/src/components/import/ImportPage.js
@@ -59,7 +59,7 @@ const Page = () => {
             {valueCount > maxValues && (
               <div className={styles.warning}>
                 {i18n.t(
-                  "You can maximum import {{maxValues}} values in a single import, but you are trying to import {{valueCount}} values for {{orgUnitCount}} organisation units over {{daysCount}} days. Please select a smaller period or fewer organisation units. You can always import more data later.",
+                  "You can maximum import {{maxValues}} data values in a single import, but you are trying to import {{valueCount}} values for {{orgUnitCount}} organisation units over {{daysCount}} days. Please select a smaller period or fewer organisation units. You can always import more data later.",
                   {
                     maxValues,
                     valueCount,

--- a/src/components/import/ImportPage.js
+++ b/src/components/import/ImportPage.js
@@ -59,7 +59,7 @@ const Page = () => {
             {valueCount > maxValues && (
               <div className={styles.warning}>
                 {i18n.t(
-                  "You can maximum import {{maxValues}} data values in a single import, but you are trying to import {{valueCount}} values for {{orgUnitCount}} organisation units over {{daysCount}} days. Please select a smaller period or fewer organisation units. You can always import more data later.",
+                  "You can maximum import {{maxValues}} data values in a single import, but you are trying to import {{valueCount}} values for {{orgUnitCount}} organisation units over {{daysCount}} days. Please select a shorter period or fewer organisation units. You can always import more data later.",
                   {
                     maxValues,
                     valueCount,

--- a/src/components/import/styles/ImportPage.module.css
+++ b/src/components/import/styles/ImportPage.module.css
@@ -44,3 +44,9 @@
 .instructions {
   flex: 1 2 20em;
 }
+
+.warning {
+  color: red;
+  font-size: 14px;
+  margin-top: 6px;
+}

--- a/src/hooks/useOrgUnitCount.js
+++ b/src/hooks/useOrgUnitCount.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+import { useDataQuery } from "@dhis2/app-runtime";
+import { ORG_UNITS_QUERY } from "./useOrgUnits";
+
+const useOrgUnitCount = (parent, level) => {
+  const [orgUnitCount, setOrgUnitCount] = useState(0);
+
+  const { refetch } = useDataQuery(ORG_UNITS_QUERY, {
+    lazy: true,
+    variables: { parent, level },
+    onComplete: ({ geojson }) => setOrgUnitCount(geojson.features.length),
+  });
+
+  useEffect(() => {
+    if (parent && level) {
+      refetch({ parent, level });
+    }
+  }, [refetch, parent, level]);
+
+  return orgUnitCount;
+};
+
+export default useOrgUnitCount;

--- a/src/hooks/useOrgUnits.js
+++ b/src/hooks/useOrgUnits.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useDataQuery } from "@dhis2/app-runtime";
 
-const ORG_UNITS_QUERY = {
+export const ORG_UNITS_QUERY = {
   geojson: {
     resource: "organisationUnits.geojson",
     params: ({ parent, level }) => ({

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -37,6 +37,5 @@ export const getNumberOfDays = (startDate, endDate) => {
   return diff / (1000 * 60 * 60 * 24) + 1;
 };
 
-export const getNumberOfDaysFromPeriod = (period) => {
-  return getNumberOfDays(period.startDate, period.endDate);
-};
+export const getNumberOfDaysFromPeriod = (period) =>
+  getNumberOfDays(period.startDate, period.endDate);

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -36,3 +36,7 @@ export const getNumberOfDays = (startDate, endDate) => {
   const diff = end - start;
   return diff / (1000 * 60 * 60 * 24) + 1;
 };
+
+export const getNumberOfDaysFromPeriod = (period) => {
+  return getNumberOfDays(period.startDate, period.endDate);
+};


### PR DESCRIPTION
This PR will set 50,000 as a maximum number of data values in a single import, and show a warning if this is exceeded:

<img width="651" alt="Screenshot 2024-03-07 at 13 29 00" src="https://github.com/dhis2/climate-data-app/assets/548708/c22b5cb0-46a1-490b-91dc-c49952278540">
